### PR TITLE
Upgrade tracy/tracy dependency to ^2.11.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "nette/http": "^3.3.0",
     "nette/utils": "^4.0.4",
     "latte/latte": "^3.0.16",
-    "tracy/tracy": "^2.10.7",
+    "tracy/tracy": "^2.11.2",
 
     "contributte/console": "^0.11.0",
     "contributte/event-dispatcher": "^0.9.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93c6bca5a4ab1eee795d4bef991851ec",
+    "content-hash": "94f2f79f55c7cb4c9df5082074e891d6",
     "packages": [
         {
             "name": "contributte/console",
@@ -3335,16 +3335,16 @@
         },
         {
             "name": "tracy/tracy",
-            "version": "v2.11.1",
+            "version": "v2.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/tracy.git",
-                "reference": "c4a03c921af532b74c63edd8bf3f68a99dec7e77"
+                "reference": "9b265515240a6768347525d463ef04207b4e7d98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/tracy/zipball/c4a03c921af532b74c63edd8bf3f68a99dec7e77",
-                "reference": "c4a03c921af532b74c63edd8bf3f68a99dec7e77",
+                "url": "https://api.github.com/repos/nette/tracy/zipball/9b265515240a6768347525d463ef04207b4e7d98",
+                "reference": "9b265515240a6768347525d463ef04207b4e7d98",
                 "shasum": ""
             },
             "require": {
@@ -3360,9 +3360,11 @@
                 "nette/di": "^3.0",
                 "nette/http": "^3.0",
                 "nette/mail": "^3.0 || ^4.0",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.6",
                 "nette/utils": "^3.0 || ^4.0",
-                "phpstan/phpstan": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "psr/log": "^1.0 || ^2.0 || ^3.0"
             },
             "type": "library",
@@ -3407,9 +3409,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/tracy/issues",
-                "source": "https://github.com/nette/tracy/tree/v2.11.1"
+                "source": "https://github.com/nette/tracy/tree/v2.11.2"
             },
-            "time": "2026-02-08T02:51:45+00:00"
+            "time": "2026-02-20T05:56:23+00:00"
         }
     ],
     "packages-dev": [
@@ -3633,12 +3635,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.4"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary
This pull request updates the tracy/tracy dependency from ^2.10.7 to ^2.11.2 to leverage improvements and bug fixes in the latest stable version.

## Changes
- Updated `tracy/tracy` version constraint in composer.json from `^2.10.7` to `^2.11.2`

## Details
This is a minor version bump that brings in new features and fixes from Tracy 2.11.x releases while maintaining backward compatibility within the ^2.x version range.

https://claude.ai/code/session_01PfGZVduqFnZYEBw16FnNDZ